### PR TITLE
Change parsing of boxed values in counterexamples

### DIFF
--- a/Source/DafnyLanguageServer/CounterExampleGeneration/DafnyModel.cs
+++ b/Source/DafnyLanguageServer/CounterExampleGeneration/DafnyModel.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Dafny.LanguageServer.CounterExampleGeneration {
       fNull, fSetUnion, fSetIntersection, fSetDifference, fSetUnionOne,
       fSetEmpty, fSeqEmpty, fSeqBuild, fSeqAppend, fSeqDrop, fSeqTake,
       fSeqUpdate, fSeqCreate, fU2Real, fU2Bool, fU2Int,
-      fMapDomain, fMapElements, fMapBuild, fIs, fIsBox;
+      fMapDomain, fMapElements, fMapBuild, fIs, fIsBox, fUnbox;
     private readonly Dictionary<Model.Element, Model.FuncTuple> datatypeValues = new();
 
     // maps a numeric type (int, real, bv4, etc.) to the set of integer
@@ -86,6 +86,7 @@ namespace Microsoft.Dafny.LanguageServer.CounterExampleGeneration {
       fU2Int = new ModelFuncWrapper(this, "U_2_int", 1, 0);
       fTag = new ModelFuncWrapper(this, "Tag", 1, 0);
       fBv = new ModelFuncWrapper(this, "TBitvector", 1, 0);
+      fUnbox = new ModelFuncWrapper(this, "$Unbox", 2, 0);
       InitDataTypes();
       RegisterReservedChars();
       RegisterReservedInts();
@@ -841,7 +842,11 @@ namespace Microsoft.Dafny.LanguageServer.CounterExampleGeneration {
         return null;
       }
       var unboxed = fBox.AppWithResult(elt);
-      return unboxed != null ? unboxed.Args[0] : elt;
+      if (unboxed != null) {
+        return Unbox(unboxed.Args[0]);
+      }
+      unboxed = fUnbox.AppWithArg(1, elt);
+      return unboxed != null ? Unbox(unboxed.Result) : elt;
     }
   }
 }


### PR DESCRIPTION
A minor change to the way counterexample parsing processes boxed values. 

<!-- Is this a user-visible change?  Remember to update RELEASE_NOTES.md -->

<!-- Is this a bug fix?  Remember to include a test in Test/git-issues/ -->

<!-- Is this a bug fix for an issue introduced in the latest release?  Mention this in the PR details and ensure a patch release is considered -->

<!-- Does this PR need tests?  Add them to `Test/` or to `Source/*.Test/…` and run them with `dotnet test` -->

<!-- Are you moving a large amount of code? Read CONTRIBUTING.md to learn how to do that while maintaining git history -->

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
