### PR TITLE
Fix line number to pos conversion

### DIFF
--- a/Source/DafnyDriver/CoverageReporter.cs
+++ b/Source/DafnyDriver/CoverageReporter.cs
@@ -151,7 +151,7 @@ public class CoverageReporter {
         .TakeWhile((c, i) => allFiles.All(s => s[i] == c)).ToArray()).Length;
     Dictionary<string, string> sourceFileToCoverageReport = new Dictionary<string, string>();
     foreach (var fileName in allFiles) {
-      var directoryForFile = Path.Combine(sessionDirectory, Path.GetDirectoryName(fileName)?[prefixLength..] ?? "");
+      var directoryForFile = Path.Combine(sessionDirectory, Path.GetDirectoryName(fileName)?[prefixLength..].TrimStart('/') ?? "");
       var pathToRoot = Path.GetRelativePath(directoryForFile, sessionDirectory);
       Directory.CreateDirectory(directoryForFile);
       for (int i = 0; i < reports.Count; i++) {

--- a/Source/DafnyTestGeneration/Utils.cs
+++ b/Source/DafnyTestGeneration/Utils.cs
@@ -139,6 +139,28 @@ namespace DafnyTestGeneration {
       string uniqueId = options.TestGenOptions.Mode != TestGenerationOptions.Modes.Block ? "#" + block.UniqueId : "";
       return state == null ? null : Regex.Replace(state, @"\s+", "") + uniqueId;
     }
+    
+    /// <summary>
+    /// Given a file URI and a one-based line number, return the position of the character at the start of the line.
+    /// Use a cache to prevent reading the same file twice.
+    /// </summary>
+    public static int GetPosFromLine(Uri fileUri, int lineNum, Dictionary<Uri, int[]> cache) {
+      if (!cache.ContainsKey(fileUri)) {
+        var source = new StreamReader(fileUri.LocalPath).ReadToEnd();
+        var lines = source.Split("\n");
+        var pos = 0;
+        var line = 0;
+        var linePositions = new int[lines.Length + 1];
+        while (pos < source.Length) {
+          linePositions[line] = pos;
+          pos += lines[line].Length + 1;
+          line++;
+        }
+        linePositions[^1] = pos;
+        cache[fileUri] = linePositions;
+      }
+      return cache[fileUri][lineNum - 1]; // subtract one because lineNum is one-based
+    }
 
     public static IList<object> GetAttributeValue(Implementation implementation, string attribute) {
       var attributes = implementation.Attributes;


### PR DESCRIPTION
Added a utility function that can convert a line number to a pos number and store that information in a cache for that file.
Also fixed a minor issue in a call to `Path.Combine`.

Fixes #

<!-- Is this a user-visible change?  Remember to update RELEASE_NOTES.md -->

<!-- Is this a bug fix?  Remember to include a test in Test/git-issues/ -->

<!-- Is this a bug fix for an issue introduced in the latest release?  Mention this in the PR details and ensure a patch release is considered -->

<!-- Does this PR need tests?  Add them to `Test/` or to `Source/*.Test/…` and run them with `dotnet test` -->

<!-- Are you moving a large amount of code? Read CONTRIBUTING.md to learn how to do that while maintaining git history -->

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
